### PR TITLE
Updated library names & changed capitalization of file names

### DIFF
--- a/Max3421e.cpp
+++ b/Max3421e.cpp
@@ -3,6 +3,7 @@
 #include "Max3421e.h"
 // #include "Max3421e_constants.h"
 
+
 static byte vbusState;
 
 /* Functions    */
@@ -46,8 +47,8 @@ void MAX3421E::toggle( byte pin )
 void MAX3421E::regWr( byte reg, byte val)
 {
       Select_MAX3421E;
-      Spi.transfer( reg + 2 ); //set WR bit and send register number
-      Spi.transfer( val );
+      SPI.transfer( reg + 2 ); //set WR bit and send register number
+      SPI.transfer( val );
       Deselect_MAX3421E;
 }
 /* multiple-byte write */
@@ -55,9 +56,9 @@ void MAX3421E::regWr( byte reg, byte val)
 char * MAX3421E::bytesWr( byte reg, byte nbytes, char * data )
 {
     Select_MAX3421E;            //assert SS
-    Spi.transfer ( reg + 2 );   //set W/R bit and select register   
+    SPI.transfer ( reg + 2 );   //set W/R bit and select register   
     while( nbytes ) {                
-        Spi.transfer( *data );  // send the next data byte
+        SPI.transfer( *data );  // send the next data byte
         data++;                 // advance the pointer
         nbytes--;
     }
@@ -69,8 +70,8 @@ byte MAX3421E::regRd( byte reg )
 {
   byte tmp;
     Select_MAX3421E;
-    Spi.transfer ( reg );         //send register number
-    tmp = Spi.transfer ( 0x00 );  //send empty byte, read register contents
+    SPI.transfer ( reg );         //send register number
+    tmp = SPI.transfer ( 0x00 );  //send empty byte, read register contents
     Deselect_MAX3421E; 
     return (tmp);
 }
@@ -79,9 +80,9 @@ byte MAX3421E::regRd( byte reg )
 char * MAX3421E::bytesRd ( byte reg, byte nbytes, char  * data )
 {
     Select_MAX3421E;    //assert SS
-    Spi.transfer ( reg );     //send register number
+    SPI.transfer ( reg );     //send register number
     while( nbytes ) {
-        *data = Spi.transfer ( 0x00 );    //send empty byte, read register contents
+        *data = SPI.transfer ( 0x00 );    //send empty byte, read register contents
         data++;
         nbytes--;
     }

--- a/Max3421e.h
+++ b/Max3421e.h
@@ -2,13 +2,12 @@
 #ifndef _MAX3421E_H_
 #define _MAX3421E_H_
 
+#include <SPI.h>
+#include "Arduino.h"
+#include <Max3421e_constants.h>
 
-#include <Spi.h>
-//#include <WProgram.h>
-#include "WProgram.h"
-#include "Max3421e_constants.h"
 
-class MAX3421E : public SPI {
+class MAX3421E : public SPIClass {
     // byte vbusState;
 
     public:

--- a/Usb.h
+++ b/Usb.h
@@ -2,7 +2,7 @@
 #ifndef _usb_h_
 #define _usb_h_
 
-#include <MAX3421E.h>
+#include <Max3421e.h>
 #include "ch9.h"
 
 /* Common setup data constant combinations  */


### PR DESCRIPTION
These files didn't work when I tried to compile them using `Arduino 1.6.10`, so I fixed them. First of all, the compiler complained that he didn't find files that weren't capitalized correctly. Then, some Arduino libraries changed some names: `Spi.h` became `SPI.h`, `SPI` became `SPIClass` and `WProgram.h` became `Arduino.h`.

I wasn't able to try them in practice yet, but at least they now compile without error.
